### PR TITLE
Add `.luacheckrc` and fix warnings.

### DIFF
--- a/.luacheckrc
+++ b/.luacheckrc
@@ -1,0 +1,9 @@
+
+read_globals = {
+	"minetest",
+	"vector",
+}
+
+globals = {
+	"player_monoids",
+}

--- a/init.lua
+++ b/init.lua
@@ -65,7 +65,7 @@ function mon_meta:add_change(player, value, id)
 	local p_name = player:get_player_name()
 
 	local def = self.def
-        
+
 	local p_effects = self.player_map[p_name]
 	if p_effects == nil then
 		p_effects = {}

--- a/standard_monoids.lua
+++ b/standard_monoids.lua
@@ -1,17 +1,5 @@
 -- Standard effect monoids, to provide canonicity.
 
-local function mult(x, y) return x * y end
-
-local function mult_fold(elems)
-	local tot = 1
-
-	for k,v in pairs(elems) do
-		tot = tot * v
-	end
-
-	return tot
-end
-
 local function v_mult(v1, v2)
 	local res = {}
 
@@ -26,7 +14,7 @@ local function v_mult_fold(identity)
 	return function(elems)
 		local tot = identity
 
-		for k, v in pairs(elems) do
+		for _, v in pairs(elems) do
 			tot = v_mult(tot, v)
 		end
 
@@ -42,7 +30,7 @@ player_monoids.speed = monoid({
 	combine = function(x, y) return x * y end,
 	fold = function(elems)
 		local res = 1
-		for k, v in pairs(elems) do
+		for _, v in pairs(elems) do
 			res = res * v
 		end
 
@@ -63,7 +51,7 @@ player_monoids.jump = monoid({
 	combine = function(x, y) return x * y end,
 	fold = function(elems)
 		local res = 1
-		for k, v in pairs(elems) do
+		for _, v in pairs(elems) do
 			res = res * v
 		end
 
@@ -83,7 +71,7 @@ player_monoids.gravity = monoid({
 	combine = function(x, y) return x * y end,
 	fold = function(elems)
 		local res = 1
-		for k, v in pairs(elems) do
+		for _, v in pairs(elems) do
 			res = res * v
 		end
 
@@ -103,7 +91,7 @@ player_monoids.gravity = monoid({
 player_monoids.fly = monoid({
 	combine = function(p, q) return p or q end,
 	fold = function(elems)
-		for k, v in pairs(elems) do
+		for _, v in pairs(elems) do
 			if v then return true end
 		end
 
@@ -130,7 +118,7 @@ player_monoids.fly = monoid({
 player_monoids.noclip = monoid({
 	combine = function(p, q) return p or q end,
 	fold = function(elems)
-		for k, v in pairs(elems) do
+		for _, v in pairs(elems) do
 			if v then return true end
 		end
 

--- a/test.lua
+++ b/test.lua
@@ -11,7 +11,7 @@ local function test(player)
 	local p_name = player:get_player_name()
 
 	minetest.chat_send_player(p_name, "Your speed is: " .. speed:value(player))
-	
+
 	minetest.after(3, function()
 		speed:del_change(player, ch_id)
 		minetest.chat_send_player(p_name, "Your speed is: " .. speed:value(player))


### PR DESCRIPTION
```
Checking init.lua                                 1 warning

    init.lua:68:1: line contains only whitespace

Checking standard_monoids.lua                     12 warnings

    standard_monoids.lua:3:16: unused function 'mult'
    standard_monoids.lua:5:16: unused function 'mult_fold'
    standard_monoids.lua:8:6: unused loop variable 'k'
    standard_monoids.lua:29:7: unused loop variable 'k'
    standard_monoids.lua:45:7: unused loop variable 'k'
    standard_monoids.lua:52:19: shadowing upvalue 'mult' on line 3
    standard_monoids.lua:66:7: unused loop variable 'k'
    standard_monoids.lua:73:19: shadowing upvalue 'mult' on line 3
    standard_monoids.lua:86:7: unused loop variable 'k'
    standard_monoids.lua:93:19: shadowing upvalue 'mult' on line 3
    standard_monoids.lua:106:7: unused loop variable 'k'
    standard_monoids.lua:133:7: unused loop variable 'k'

Checking test.lua                                 1 warning

    test.lua:14:1: line contains only whitespace

Total: 14 warnings / 0 errors in 3 files
```