### PR TITLE
Use mod.conf for description

### DIFF
--- a/description.txt
+++ b/description.txt
@@ -1,2 +1,0 @@
-player_monoids is a library for managing global player state, such as physics
-overrides or player visual size.

--- a/mod.conf
+++ b/mod.conf
@@ -1,1 +1,5 @@
-name=player_monoids
+name = player_monoids
+description = """ 
+A library for managing global player state, 
+such as physics overrides or player visual size.
+"""

--- a/standard_monoids.lua
+++ b/standard_monoids.lua
@@ -63,7 +63,6 @@ player_monoids.jump = monoid({
 	end,
 })
 
-
 -- Gravity monoid. Effect values are gravity multipliers.
 player_monoids.gravity = monoid({
 	combine = mult,
@@ -75,7 +74,6 @@ player_monoids.gravity = monoid({
 		player:set_physics_override(ov)
 	end,
 })
-
 
 -- Fly ability monoid. The values are booleans, which are combined by or. A true
 -- value indicates having the ability to fly.
@@ -103,7 +101,6 @@ player_monoids.fly = monoid({
 
 	end,
 })
-
 
 -- Noclip ability monoid. Works the same as fly monoid.
 player_monoids.noclip = monoid({

--- a/test.lua
+++ b/test.lua
@@ -4,6 +4,7 @@ local speed = player_monoids.speed
 minetest.register_privilege("monoid_master", {
 	description = "Allows testing of player monoids.",
 	give_to_singleplayer = false,
+	give_to_admin = true,
 })
 
 local function test(player)


### PR DESCRIPTION
Continue of #5.

Replaces `description.txt` with `mod.conf`.
Removes empty lines; the `monoid_master` privilege is given to administrator automatically.