### PR TITLE
check player object is valid before apply anything, on call backs

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -51,9 +51,12 @@ local function monoid(def)
 	setmetatable(mon, mon_meta)
 
 	minetest.register_on_leaveplayer(function(player)
-		local p_name = player:get_player_name()
-		p_map[p_name] = nil
-		v_cache[p_name] = nil
+		local p_name
+		if player then
+			p_name = player:get_player_name()
+			p_map[p_name] = nil
+			v_cache[p_name] = nil
+		end
 	end)
 
 	return mon

--- a/test.lua
+++ b/test.lua
@@ -9,14 +9,16 @@ minetest.register_privilege("monoid_master", {
 
 local function test(player)
 	local ch_id = speed:add_change(player, 10)
-	local p_name = player:get_player_name()
-
-	minetest.chat_send_player(p_name, "Your speed is: " .. speed:value(player))
-
-	minetest.after(3, function()
-		speed:del_change(player, ch_id)
+	local p_name
+	if player then
+		p_name = player:get_player_name()
 		minetest.chat_send_player(p_name, "Your speed is: " .. speed:value(player))
-	end)
+
+		minetest.after(3, function()
+			speed:del_change(player, ch_id)
+			minetest.chat_send_player(p_name, "Your speed is: " .. speed:value(player))
+		end)
+	end
 end
 
 minetest.register_chatcommand("test_monoids", {


### PR DESCRIPTION
the error was never really solved.. its just that is not happened so much anymore.. but still present in some servers..

* compatibilit with minetest 0.4.17 and 5.0.0 for player object bug minetest/minetest#8452