### PR TITLE
README.md: Return from example fold methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ newmod.speed_boosts = player_monoids.make_monoid({
 	end,
 	fold = function(tab)
 		local res = 1
-	     	for _, speed in pairs(tab) do
+		for _, speed in pairs(tab) do
 			res = math.max(res, speed)
 		end
 		return res

--- a/README.md
+++ b/README.md
@@ -40,10 +40,10 @@ mymod.speed_monoid = player_monoids.make_monoid({
 	end,
 	fold = function(tab)
 		local res = 1
-	     	for _, speed in pairs(tab) do
+		for _, speed in pairs(tab) do
 			res = res * speed
-	     	end
-                return res
+		end
+		return res
 	end,
 	identity = 1,
 	apply = function(speed, player)
@@ -111,8 +111,8 @@ newmod.speed_boosts = player_monoids.make_monoid({
 		local res = 1
 	     	for _, speed in pairs(tab) do
 			res = math.max(res, speed)
-	     	end
-                return res
+		end
+		return res
 	end,
 	identity = 1,
 	apply = ???

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ mymod.speed_monoid = player_monoids.make_monoid({
 	     	for _, speed in pairs(tab) do
 			res = res * speed
 	     	end
+                return res
 	end,
 	identity = 1,
 	apply = function(speed, player)
@@ -111,6 +112,7 @@ newmod.speed_boosts = player_monoids.make_monoid({
 	     	for _, speed in pairs(tab) do
 			res = math.max(res, speed)
 	     	end
+                return res
 	end,
 	identity = 1,
 	apply = ???


### PR DESCRIPTION
I was reading the README and got annoyed by this detail... so I decided to try out Github's in-browser editor and do a PR directly in the web browser.

I'm pretty sure I didn't get the indentation right because Github made it impossible to figure out what was going on in regards to that, but you get the idea. So, please fix the indentation that I likely messed up before merging this.

This fix is otherwise correct, right? I can't imagine how a fold method can work without returning anything and without saving any state either.