### PR TITLE
Overhaul the API documentation

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,169 +1,218 @@
 # Player Monoids Library Documentation
 
-
-
-## Table of Contents
-1. [Introduction](#introduction)
-   - 1.1 [Use Cases and Types](#use-cases-and-types)
-   - 1.2 [Definition Structure](#definition-structure)
-2. [Branch System](#branch-system)
-3. [API Reference](#api-reference)
-
-
-
 ## Introduction
 
-The **Player Monoids Library** is designed to solve the problem of conflicting player state changes in Luanti when multiple mods are involved. For example, one mod might want to increase a player's speed, while another mod reduces it. Without a structured way to combine these changes, mods can overwrite each other's effects, leading to unpredictable behavior.
+The **Player Monoids Library** is designed to solve the problem of conflicting player state changes in Luanti when multiple mods are involved.
+For example, one mod might want to increase a player's speed (`ObjectRef:set_physics_override`), while another mod reduces it. Without a structured way to combine these changes, mods can overwrite each other's effects, leading to unpredictable behavior.
 
-This library introduces **monoids**, which represent specific aspects of the player state, such as speed modifiers, jump height, or even custom states like corruption levels or reputation systems. Monoids allow changes from multiple mods to be combined consistently and predictably. Additionally, the library supports **branches**, which isolate changes into separate contexts. This makes it possible to maintain different states for different scenarios, such as minigames or alternate dimensions.
+**Undocumented functions or variables may change at any time without notice.**
 
-### Use Cases and Types
 
-Monoids are useful for managing both built-in player attributes and custom mod-defined states. For example:
+### Terminology
 
-- **Built-in Attributes**: Monoids can manage physics overrides like speed multipliers, jump height modifiers, or gravity changes. They can also handle privilege management (e.g., enabling or disabling fly or noclip combining booleans with the *or* operator) or armor values.
-- **Custom Mod States**: Mods can define their own monoids for features like corruption levels, reputation systems, or environmental effects. For instance, you could create a monoid that tracks "lucky directions" as vectors.
+- **Monoid**: Represents one aspect of the player state
+    - Examples: movement speed factor, corruption level, reputation level, the `fast` privilege,
+      environmental effects
+- **Branch**: A situation or time-based context of the player.
+    - Monoids of the active branch are applied to the player. This allows context-based overriding.
+    - Use-cases: freezing the player (sleeping in bed), increased armor groups in PvP,
+      increased jump height while playing a minigame.
+
+
+## Monoids
 
 Monoids can be categorized based on how they combine values:
-- **Multiplicative Monoids**: Combine values using multiplication (e.g., speed multipliers).
-- **Additive Monoids**: Combine values using addition (e.g., armor bonuses).
-- **Custom Logic Monoids**: Use custom logic to combine values (e.g., vectors for directional effects).
 
----
+- **Multiplicative**: Combine values using multiplication (e.g., speed multipliers).
+- **Additive**: Combine values using addition (e.g., armor bonuses).
+- **Custom Logic**: Use custom logic to combine values (e.g., vectors for directional effects).
 
-### Definition Structure
 
-A monoid is defined as a Lua table that specifies how values are combined, applied to the player, and managed. The structure includes the following fields:
+### Built-in monoids
+
+[standard_monoids.lua](standard_monoids.lua) provides the following *monoids*:
+
+- Player physics overrides: (multipliers)
+     - `player_monoids.speed`: movement speed
+     - `player_monoids.jump`: jump speed
+     - `player_monoids.gravity`: acceleration.
+- Privilege management (*OR*-combined): `fly`, `noclip`
+- Player appearance: (multipliers)
+    - `player_monoids.collisionbox`: Scales the player’s collision box with component-wise multiplication.
+    - `player_monoids.visual_size`: Scales the player’s visual size as a 2D multiplier vector.
+
+
+### Monoid Definition
+
+A *monoid* is defined as a Lua table. See also: `player_monoids.make_monoid`.
+You may find an example below.
 
 ```lua
 {
-  combine = function(elem1, elem2),  -- Combines two elements (must be associative)
-  fold = function({elems}),          -- Combines multiple elements
-  identity = value,                  -- Neutral/default value
-  apply = function(value, player),   -- Applies the combined value to the player
-  on_change = function(old, new, player, branch),  -- Optional callback for value changes
-  listen_to_all_changes = boolean    -- Optional; enables branch-wide callbacks
+	identity = value,                   -- Neutral/default value
+	combine = function(value1, value2), -- Combines two values
+	fold = function({values, ...}),     -- Combines multiple elements
+	apply = function(value, player),    -- Applies the combined value to the player
+	on_change = function(old_value, new_value, player, branch_name),  -- Optional callback for value changes
+	listen_to_all_changes = boolean     -- Optional; enables callbacks across branches
 }
 ```
 
-Each field plays a specific role in defining the behavior of the monoid:
+- `identity`
+    - This is the base onto which all values of the active monoids are applied to
+    . As a rule of thumb:
+        - If `combine` is multiplicative: `identity = 1.0`
+        - If `combine` is additive: `identity = 0`
+- `combine = function(value1, value2)`
+    - Combines two values, originating from separate `monoid:add_change`.
+    - Return value: output value (same type as `value1` and `value2`)
+    - This function *must* be associative. Hence these two expressions must be equal:
+        - `combine(a, combine(b, c))`
+        - `combine(combine(a, b), c)`
+- `fold = function({ value1, value2, ... })`
+    - Identical logic as in `combine`, but accepting more values.
+- `apply = function(value, player)`
+    - `player` (ObjectRef): Target to apply the `value`
+    - Example: `player:set_physics_override({ speed = value })`
+- `on_change = function(old_value, new_value, player, branch)`
+    - Optional. This callback is run after a new value was evaluated.
+    - `branch` (table): This is equal to `monoid:get_active_branch(player)`.
+- `listen_to_all_changes = boolean`
+    - When set to `true`, `on_change` will be called on *every change*, even if `branch` is not the currently active branch.
+    - Default: `false`.
+- `on_branch_created(monoid, player, branch_name)`
+    - Optional. Called when a new branch is created.
+- `on_branch_deleted(monoid, player, branch_name)`
+    - Optional. Called when a branch is deleted.
 
-- **`combine`** defines how two values are merged. The function must be associative, meaning that `combine(a, combine(b, c))` should be equivalent to `combine(combine(a, b), c)`. For example, in a speed multiplier monoid:
+**Types of the parameters above:**
+
+- `branch_name`: a `string`. e.g. `"main"` (default branch)
+- `monoid`: see [Monoid Definition]
+- `player`: an `ObjectRef` instance
+
+
+#### Example
+
+In order to overwrite the `speed` physics override (a built-in monoid), the following
+definition could be used:
 
 ```lua
-  combine = function(a, b) return a * b end
+{
+	identity = 1,
+	combine = function(a, b)
+		-- Scale linearly, based on the default 1.
+		return a * b
+	end,
+	fold = function(t)
+		-- Same as `combine` but for more elements
+		local result = 1
+		for _, v in pairs(t) do
+			result = result * v
+		end
+		return result
+	end,
+	apply = function(multiplier, player)
+		player:set_physics_override({speed = multiplier})
+	end,
+	on_change = function(old_val, new_val, player, branch)
+		local branch_name = branch:get_name()
+		core.log("Speed changed from " .. old_val .. " to " .. new_val .. " on branch " .. branch_name)
+	end
 ```
 
-- **`fold`** combines multiple values at once by applying `combine` iteratively. It processes a table of values and merges them into one:
-  
-```lua
-fold = function(t)
- local result = 1
- for _, v in pairs(t) do result = result * v end
- return result
-end
-```
 
-- **`identity`** is the neutral default value that will be used when there are no status effects active for a particular monoid. When combined with any other value, it leaves it unchanged. For example:
-   - Speed multipliers: `identity = 1.0`
-   - Additive bonuses: `identity = 0`
-
-- **`apply`** translates the combined monoid value into actual effects on the player's state:
-  
-```lua
-apply = function(multiplier, player)
- player:set_physics_override({speed = multiplier})
-end
-```
-
-- **`on_change`** is an optional callback triggered whenever the monoid's value changes for a player:
-  
-```lua
-on_change = function(old_val, new_val, player, branch)
- local branch_name = branch:get_name()
- core.log("Speed changed from " .. old_val .. " to " .. new_val .. " on branch " .. branch_name)
-end
-```
-
-- **`listen_to_all_changes`**, when set to `true`, ensures that `on_change` is triggered for all branch updates instead of just the active branch.
-
-- **`on_branch_created(monoid, player, branch_name)`**: Optional callback, called when a new branch is created.
-
-- **`on_branch_deleted(monoid, player, branch_name)`**: Optional callback, called when a branch is deleted.
-
----
-
-
-
-## Branch System
+## Branches
 
 Branches allow mods to isolate state changes into separate contexts without interfering with each other. Each branch maintains its own set of modifiers and can be activated independently.
+For each player exactly one branch is active at a time.
 
-By default, every player starts on the `"main"` branch. This branch represents their normal state and is created automatically when a monoid is initialized. Additional branches can be created and accessed in three ways:
-- Using `monoid:new_branch(player, name)` to create a new branch without activating it
-- Using `monoid:checkout_branch(player, name)` to switch the player's active branch, creating it if needed
-- Using `monoid:get_branch(name)` to get a wrapper for managing the branch at any time, or false if it doesn't exist
+- Default branch: `"main"`
+- Default values: as given by `monoid.identity`
 
-When switching branches with `checkout_branch`, the player's state is immediately updated to reflect the combined value of the new active branch.
+**Branch management and assignemnt:**
+
+- New branch: `monoid:new_branch(player, name)`
+- Switch to branch: `monoid:checkout_branch(player, name)`
+- Get branch: `monoid:get_branch(name)`
 
 The inactive branches can still be modified in the background, but their combined values won't affect the player's state until they get activated.
 
----
-
-
 
 ## API Reference
-#### `player_monoids.make_monoid(monoid_def)`
-The `monoid` object mentioned in this API's methods has to first be created using this function. `monoid_def` is a table defining the monoid’s behavior (see [Definition Structure](#definition-structure)).
 
----
+*Optional arguments are denoted with `[, arg1]`.
 
-#### `monoid:add_change(player, value[, id, branch_name])`
-Applies a change represented by `value` to the player. Takes a `player` object, a `value` parameter that must be valid for this monoid, an optional *branch-unique* string `id` (if not provided, a random one will be generated), and an optional `branch_name` parameter (if not provided, the `"main"` branch will be used). Returns the ID of the added change.
+Notes:
 
----
+- `branch_name`: a `string`
+- `id`: a `number` or a unique mod-defined `string` to identify the change, e.g. `my_boots_mod:speedy_boots`.
+- `monoid`: see [Monoid Definition]
+- `player`: an `ObjectRef` instance
 
-#### `monoid:del_change(player, id[, branch_name])`
-Removes the change represented by `id` from the player. If `branch_name` is not provided, the `"main"` branch will be used.
 
----
+### Monoid API
 
-#### `monoid:value(player[, branch_name])`
-Gets the value of this monoid for a specific player and branch. Takes a player object and an optional `branch_name` parameter. If `branch_name` is not provided, the **active branch** will be used. Returns the combined value for this monoid.
+- `player_monoids.make_monoid(monoid_def)`
+    - Initializes and returns a new monoid based on `monoid_def`.
+    - `monoid_def` (table): see [Monoid Definition]
+- `monoid:add_change(player, value[, id, branch_name])`
+    - Applies a change represented by `value` to the player.
+    - If the change `id` already exists in the branch, it will be overwritten.
+    - If no `branch_name` is provided, `"main"` will be used.
+    - Returns `id` or a generated unique ID of the change.
+- `monoid:del_change(player, id[, branch_name])`
+    - Removes the change represented by `id` from the player.
+    - If no `branch_name` is provided, `"main"` will be used.
+- `monoid:value(player[, branch_name])`
+    - Gets the value of this monoid for the specified player and branch.
+    - If no `branch_name` is provided, the **active branch** will be used.
+    - Returns the combined value for this monoid.
 
----
 
-#### `monoid:new_branch(player, branch_name)`
-Creates a new branch for a player, but does not switch to it. Returns the handler object for the new branch.
-- The returned handler provides methods for managing changes specific to that branch:
-   - **`add_change(player, value[, id])`**: adds a change to this specific branch.
-   - **`del_change(player, id)`**: removes a change from this specific branch by its ID.
-   - **`value(player)`**: gets this branch’s current combined value for a specific player.
-   - **`get_name()`**: retrieves this branch’s name as a string.
-   - **`reset(player)`**: clears all changes on this branch for the specified player.
-   - **`delete(player)`**: deletes this branch for the specified player. If the deleted branch is the active branch, the active branch will be switched to `"main"`. You can't delete the main branch.
+### Branch API
 
----
+-  `monoid:new_branch(player, branch_name)`
+    - Creates a new branch for a player, but does not switch to it.
+    - Returns a [Branch Handler] object.
+- `mononid:checkout_branch(player, branch_name)`
+    - Switches the player's active branch to the specified one, creating it if it doesn't exist.
+    - The player's state is immediately updated to reflect the combined value of the new active branch.
+    - Returns a [Branch Handler] object.
+- `monoid:get_active_branch(player)`
+    - Gets a [Branch Handler] object representing the player's currently active branch.
+- `monoid:get_branch(branch_name)`
+    - Retrieves a handler object for the specified branch.
+    - Returns `false` if the branch does not exist.
+- `monoid:get_branches(player)`
+    - Returns a table:
+        - Key: string, branch name
+        - Value: [Branch Handler] object
+- `monoid:reset_branch(player[, branch_name])`
+    - Clears all changes associated with a player's branch.
+    - If no branch name is provided, `"main"` will be used.
 
-#### `mononid:checkout_branch(player, name)`
-Switches the player's active branch to the specified one, creating it if it doesn't exist. Returns the handler object for the new branch.
 
----
+#### Branch Handler
 
-#### `monoid:get_active_branch(player)`
-Gets a handler object representing the player's currently active branch.
+The branch handler (table) provides methods for managing changes specific to the branch.
 
----
+**Functions:**
 
-#### `monoid:get_branch(name)`
-Retrieves a handler object for the specified branch. Returns `false` if the branch does not exist.
-
----
-
-#### `monoid:get_branches(player)`
-Returns a table of branch wrappers, keyed by branch name, for all branches associated with the player.
-
----
-
-#### `monoid:reset_branch(player[, branch_name])`
-Clears all changes associated with a player's branch. If no branch name is provided, it resets `"main"` by default.
+- `branch:get_name()`
+    - Retrieves this branch’s name as a string.
+- `branch:add_change(player, value[, id])`:
+    - Adds a change to this branch.
+    - Wrapper for `monoid:add_change`
+- `branch:del_change(player, id)`
+    - Removes a change from this branch by its ID.
+    - Wrapper for `monoid:del_change`
+- `branch:value(player)`
+    - Evaluates and returns this branch’s current combined value for a specific player.
+    - Wrapper for `monoid:value`
+- `branch:reset(player)`
+    - Discards all changes (`id` + `value`) belonging to this branch and player.
+- `branch:delete(player)`
+    - Deletes this branch for the specified player.
+    - If the deleted branch is the active branch, the active branch will be switched to `"main"`.
+    - The `"main"` branch cannot be deleted.

--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Player Monoids Library
 
-This is a small library for managing global player state in Luanti, ensuring that multiple mods can modify player attributes without conflicts. The README provides an overview of the mod's purpose and functionality. For a detailed breakdown of available functions and usage, refer to **API.md**.
+This is a small library for managing global player state in Luanti, ensuring that multiple mods can modify player attributes without conflicts. The README provides an overview of the mod's purpose and functionality. For a detailed breakdown of available functions and usage, refer to **[API.md](API.md)**.
 
 This mod introduces **monoids**, which represent specific aspects of player state, such as speed modifiers, jump height, or even custom attributes like corruption levels or reputation systems. Monoids allow multiple mods to apply effects in a structured manner, preventing unintended overrides.
 
-Additionally, the mod now includes **branches**, which allow different states to exist independently. This is useful for features like minigames, temporary effects, or alternate player states that should not interfere with the main game.
+Additionally, the mod includes **branches**, which allow different states to exist independently. This is useful for features like minigames, temporary effects, or alternate player states that should not interfere with the main game.
 
 ## Global Player State
 
@@ -14,7 +14,9 @@ For example, a player could be under a speed boost effect from a `playereffects`
 
 Player Monoids prevents this issue by allowing changes to be layered and combined correctly using monoids and branch-based state management.
 
-## Monoids
+## [Monoids](API.md)
+
+The functions documentation can be found in the **[API.md](API.md)** file.
 
 ### Creation
 
@@ -131,28 +133,6 @@ end
 
 This ensures that our boost calculation stays separate while still being compatible with other modifications. You could also introduce another nested monoid for handling slow effects, ensuring only the most significant reduction takes effect.&#x20;
 
-## Predefined monoids
-
-### Physics Overrides
-
-These monoids modify physics properties using multipliers:
-
-- `player_monoids.speed`
-- `player_monoids.jump`
-- `player_monoids.gravity`
-
-### Privileges
-
-These monoids toggle player privileges, using boolean logic:
-
-- `player_monoids.fly`
-- `player_monoids.noclip`
-
-### Other
-
-- `player_monoids.collisionbox` - Adjusts the player’s collision box with component-wise multiplication.
-- `player_monoids.visual_size` - Modifies the player’s visual size as a 2D multiplier vector.
-
 ## Caveats
 
 - If the global state managed by a monoid is modified by something other than the monoid, you will have the same problem as when two mods both independently try to modify global state without going through a monoid.
@@ -161,7 +141,3 @@ These monoids toggle player privileges, using boolean logic:
 - The order that different effects get combined together is based on key order, which may not be predictable. So you should try to make your monoids commutative in addition to associative, or at least not care if the order of two changes is swapped.
 - Mods should account for the fact that the active branch may change at any time - they should not assume that their effects will always be applied to the player.
 - If a mod wants to make sure to always be working with the main branch values, it should be doing that through the optional branch_name parameter in the monoid functions (such as `monoid:value(player, "main")`, and/or by implementing branch checks in `on_change()`).
-
----
-
-For more details, including function signatures and advanced usage, refer to **API.md**.


### PR DESCRIPTION
This converts API.md into a more dense format as seen in the Luanti engine 'lua_api.md' file.

Feedback is welcome. If there is none in a week, I'll merge the PR as-is.